### PR TITLE
[bugfix] Strange character when using listings package

### DIFF
--- a/elegantpaper.cls
+++ b/elegantpaper.cls
@@ -338,6 +338,7 @@
 	emphstyle={\color{frenchplum}},
 	morekeywords={DeclareSymbolFont,SetSymbolFont,toprule,midrule,bottomrule,institute,version,includegraphics,setmainfont,setsansfont,setmonofont ,setCJKmainfont,setCJKsansfont,setCJKmonofont,RequirePackage,figref,tabref,email,maketitle,keywords,zhdate,zhtoday},
 	tabsize=2,
+        showstringspaces=false,
 	backgroundcolor=\color{lightgrey}
 }
 


### PR DESCRIPTION
解决模板中使用listings包时出现奇怪字符的问题，相关链接：https://tex.stackexchange.com/questions/54183/strange-character-when-using-listings-package