### PR TITLE
feat(elegantpaper.cls): support bookmark with numbering

### DIFF
--- a/elegantpaper.cls
+++ b/elegantpaper.cls
@@ -52,7 +52,9 @@
   filecolor={winered},
   citecolor={winered},
   linktoc=all,
+  bookmarksnumbered,
 }
+\RequirePackage{bookmark}
 % settings for the hyperref and geometry
 \RequirePackage[
   left=1in,


### PR DESCRIPTION
#### Description
use `bookmark` package [2] to support bookmark feature [1].

#### Before

![image](https://user-images.githubusercontent.com/16917636/151289109-4e01cc0a-7ad3-42b9-8499-6ad7ba574e56.png)

#### After

![image](https://user-images.githubusercontent.com/16917636/151289137-336b5008-6fef-403a-ac0c-95e5a3a19f25.png)

#### Reference

[1] https://tex.stackexchange.com/a/230427
[2] https://ctan.org/pkg/bookmark?lang=en